### PR TITLE
feat: support PUPPETEER_REVISION and PUPPETEER_DEFAULT_HOST environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ if (stats) {
 const options = {
     // the chromium revision to use
     // default is puppeteer.PUPPETEER_REVISIONS.chromium
+    // or you can use PUPPETEER_REVISION environment variable
     revision: '',
 
     // additional path to detect local chromium copy (separate with a comma if multiple paths)
@@ -77,6 +78,7 @@ const options = {
     statsName: '.pcr-stats.json',
 
     // default hosts are ['https://storage.googleapis.com']
+    // or you can use PUPPETEER_DEFAULT_HOST environment variable
     hosts: [],
 
     cacheRevisions: 2,

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ const getHosts = (options) => {
     let hosts = options.hosts;
     if (!Util.isList(hosts)) {
         // default hosts
-        hosts = ['https://storage.googleapis.com'];
+        const defaultHosts = process.env.PUPPETEER_DEFAULT_HOST || 'https://storage.googleapis.com';
+        hosts = [ defaultHosts ];
     }
     return hosts;
 };
@@ -130,7 +131,7 @@ const getBrowserPlatform = () => {
 };
 
 const getChromiumRevision = async (options) => {
-    let revision = options.revision;
+    let revision = options.revision || process.env.PUPPETEER_REVISION;
     if (!revision) {
         revision = await Util.resolveBuildId(options.platform);
     }


### PR DESCRIPTION
In some countries, accessing Google services may be very slow or inaccessible. We would like to add an environment variable that allows integrators to control this behavior in CI environments.