### PR TITLE
Replace deprecated npm/Gauge for cli-progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,111 +1,147 @@
 > major version following puppeteer-core
 
-+ v24.0.1
+- v24.0.2
+
+  - replaced deprecated gauge library with cli-progress
+
+- v24.0.1
+
   - support PUPPETEER_REVISION and PUPPETEER_DEFAULT_HOST
 
-+ v24.0.0
+- v24.0.0
+
   - bump puppeteer-core@24.0.0 and @puppeteer/browsers@2.7.0
 
-+ v23.0.0
+- v23.0.0
+
   - updated puppeteer-core to ^23.1.0
 
-+ v22.0.0
+- v22.0.0
+
   - updated puppeteer-core to ^22.0.0
 
-+ v21.0.0
+- v21.0.0
+
   - updated puppeteer-core to ^21.4.1
 
-+ v20.0.0
+- v20.0.0
+
   - updated puppeteer-core to ^20.0.0
   - updated headless="new"
   - replaced puppeteer.BrowserFetcher (Deprecated) with @puppeteer/browsers
 
-+ v19.3.2
+- v19.3.2
+
   - added env PUPPETEER_EXECUTABLE_PATH to skip download when installation
 
-+ v19.3.1
+- v19.3.1
+
   - fixed minor issue for docker build
 
-+ v19.3.0
+- v19.3.0
+
   - updated ChromiumRevision to 1108766 from 1095492
 
-+ v19.2.0
+- v19.2.0
+
   - added new option downloadPath
   - code refactoring
 
-+ v19.1.0
+- v19.1.0
+
   - moved .stats.json to [user home dir]/.pcr-stats.json
 
-+ v19.0.0
+- v19.0.0
+
   - updated puppeteer-core to ^19.0.0
   - updated gauge to ^5.0.0
 
-+ v18.0.0
+- v18.0.0
+
   - updated puppeteer-core to ^18.0.5
 
-+ v17.0.0
+- v17.0.0
+
   - updated puppeteer-core to ^17.0.0
 
-+ v16.0.0
+- v16.0.0
+
   - updated puppeteer-core to ^16.0.0
 
-+ v15.0.0
+- v15.0.0
+
   - updated puppeteer-core to ^15.0.0
 
-+ v14.0.0
+- v14.0.0
+
   - updated puppeteer-core to ^14.0.0
 
-+ v12.0.0
+- v12.0.0
+
   - updated puppeteer-core to ^12.0.1
 
-+ v11.0.0
+- v11.0.0
+
   - updated puppeteer-core to ^11.0.0
 
-+ v10.0.0
+- v10.0.0
+
   - updated puppeteer-core to ^10.0.0
 
-+ v9.0.0
+- v9.0.0
+
   - updated puppeteer-core to ^9.1.1
 
-+ v8.1.1
+- v8.1.1
+
   - supported reading option from root package.json with "pcr" object
   - updated PCR(option) API to support using stats cache
 
-+ v8.0.0
+- v8.0.0
+
   - updated puppeteer-core to v8.0.0
 
-+ v7.0.0
+- v7.0.0
+
   - updated puppeteer-core to v7.1.0
 
-+ v5.2.0
+- v5.2.0
+
   - updated puppeteer-core to v5.2.1
 
-+ v5.0.1
+- v5.0.1
+
   - updated puppeteer-core to v5
   - added sync API getStats()
 
-+ v4.0.0
+- v4.0.0
+
   - updated puppeteer-core to v4
 
-+ v3.2.0
+- v3.2.0
+
   - updated puppeteer-core to v3
 
-+ v3.1.0
+- v3.1.0
+
   - updated puppeteer-core version to 2.1.1
   - auto detect host response time and download from quicker one
 
-+ v3.0.1
-+ v2.0.2
+- v3.0.1
+- v2.0.2
+
   - added option cacheRevisions to cache multiple revisions
 
-+ v3.0.0
+- v3.0.0
+
   - updated puppeteer-core version to v2.0.0
 
-+ v2.0.1
+- v2.0.1
+
   - updated puppeteer-core version to v1.19.0
   - refactoring with async/await
   - fixed requesting timeout
 
-+ v1.0.12
+- v1.0.12
   - updated puppeteer-core version to v1.18.1
   - fixed a gauge log issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,147 +1,114 @@
 > major version following puppeteer-core
 
-- v24.0.2
-
++ v24.0.2
   - replaced deprecated gauge library with cli-progress
 
-- v24.0.1
-
++ v24.0.1
   - support PUPPETEER_REVISION and PUPPETEER_DEFAULT_HOST
 
-- v24.0.0
-
++ v24.0.0
   - bump puppeteer-core@24.0.0 and @puppeteer/browsers@2.7.0
 
-- v23.0.0
-
++ v23.0.0
   - updated puppeteer-core to ^23.1.0
 
-- v22.0.0
-
++ v22.0.0
   - updated puppeteer-core to ^22.0.0
 
-- v21.0.0
-
++ v21.0.0
   - updated puppeteer-core to ^21.4.1
 
-- v20.0.0
-
++ v20.0.0
   - updated puppeteer-core to ^20.0.0
   - updated headless="new"
   - replaced puppeteer.BrowserFetcher (Deprecated) with @puppeteer/browsers
 
-- v19.3.2
-
++ v19.3.2
   - added env PUPPETEER_EXECUTABLE_PATH to skip download when installation
 
-- v19.3.1
-
++ v19.3.1
   - fixed minor issue for docker build
 
-- v19.3.0
-
++ v19.3.0
   - updated ChromiumRevision to 1108766 from 1095492
 
-- v19.2.0
-
++ v19.2.0
   - added new option downloadPath
   - code refactoring
 
-- v19.1.0
-
++ v19.1.0
   - moved .stats.json to [user home dir]/.pcr-stats.json
 
-- v19.0.0
-
++ v19.0.0
   - updated puppeteer-core to ^19.0.0
   - updated gauge to ^5.0.0
 
-- v18.0.0
-
++ v18.0.0
   - updated puppeteer-core to ^18.0.5
 
-- v17.0.0
-
++ v17.0.0
   - updated puppeteer-core to ^17.0.0
 
-- v16.0.0
-
++ v16.0.0
   - updated puppeteer-core to ^16.0.0
 
-- v15.0.0
-
++ v15.0.0
   - updated puppeteer-core to ^15.0.0
 
-- v14.0.0
-
++ v14.0.0
   - updated puppeteer-core to ^14.0.0
 
-- v12.0.0
-
++ v12.0.0
   - updated puppeteer-core to ^12.0.1
 
-- v11.0.0
-
++ v11.0.0
   - updated puppeteer-core to ^11.0.0
 
-- v10.0.0
-
++ v10.0.0
   - updated puppeteer-core to ^10.0.0
 
-- v9.0.0
-
++ v9.0.0
   - updated puppeteer-core to ^9.1.1
 
-- v8.1.1
-
++ v8.1.1
   - supported reading option from root package.json with "pcr" object
   - updated PCR(option) API to support using stats cache
 
-- v8.0.0
-
++ v8.0.0
   - updated puppeteer-core to v8.0.0
 
-- v7.0.0
-
++ v7.0.0
   - updated puppeteer-core to v7.1.0
 
-- v5.2.0
-
++ v5.2.0
   - updated puppeteer-core to v5.2.1
 
-- v5.0.1
-
++ v5.0.1
   - updated puppeteer-core to v5
   - added sync API getStats()
 
-- v4.0.0
-
++ v4.0.0
   - updated puppeteer-core to v4
 
-- v3.2.0
-
++ v3.2.0
   - updated puppeteer-core to v3
 
-- v3.1.0
-
++ v3.1.0
   - updated puppeteer-core version to 2.1.1
   - auto detect host response time and download from quicker one
 
-- v3.0.1
-- v2.0.2
-
++ v3.0.1
++ v2.0.2
   - added option cacheRevisions to cache multiple revisions
 
-- v3.0.0
-
++ v3.0.0
   - updated puppeteer-core version to v2.0.0
 
-- v2.0.1
-
++ v2.0.1
   - updated puppeteer-core version to v1.19.0
   - refactoring with async/await
   - fixed requesting timeout
 
-- v1.0.12
++ v1.0.12
   - updated puppeteer-core version to v1.18.1
   - fixed a gauge log issue

--- a/lib/util.js
+++ b/lib/util.js
@@ -151,10 +151,10 @@ const Util = {
         if (!Util.progressBar) {
             return;
         }
-        
+
         const downloadedMB = Util.toMegabytes(downloadedBytes);
         const totalMB = Util.toMegabytes(totalBytes);
-        
+
         if (!Util.progressBarStarted && totalBytes > 0) {
             Util.progressBar.start(totalBytes, downloadedBytes, {
                 downloadedMB,

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@ const https = require('https');
 const URL = require('url');
 const EC = require('eight-colors');
 const PB = require('@puppeteer/browsers');
-const Gauge = require('gauge');
+const cliProgress = require('cli-progress');
 
 const Util = {
 
@@ -125,25 +125,47 @@ const Util = {
 
     createGauge: () => {
         Util.closeGauge();
-        Util.gauge = new Gauge();
+        Util.progressBar = new cliProgress.SingleBar({
+            format: 'Downloading Chromium - {downloadedMB} / {totalMB} [{bar}] {percentage}%',
+            barCompleteChar: '\u2588',
+            barIncompleteChar: '\u2591',
+            hideCursor: true,
+            clearOnComplete: false,
+            stopOnComplete: false
+        }, cliProgress.Presets.shades_classic);
+        Util.progressBarStarted = false;
     },
 
     closeGauge: () => {
-        if (!Util.gauge) {
+        if (!Util.progressBar) {
             return;
         }
-        Util.gauge.disable();
-        Util.gauge.hide();
-        Util.gauge = null;
+        if (Util.progressBarStarted) {
+            Util.progressBar.stop();
+        }
+        Util.progressBar = null;
+        Util.progressBarStarted = false;
     },
 
     showProgress: (downloadedBytes, totalBytes) => {
-        let per = 0;
-        if (totalBytes) {
-            per = downloadedBytes / totalBytes;
+        if (!Util.progressBar) {
+            return;
         }
-        if (Util.gauge) {
-            Util.gauge.show(`Downloading Chromium - ${Util.toMegabytes(downloadedBytes)} / ${Util.toMegabytes(totalBytes)}`, per);
+        
+        const downloadedMB = Util.toMegabytes(downloadedBytes);
+        const totalMB = Util.toMegabytes(totalBytes);
+        
+        if (!Util.progressBarStarted && totalBytes > 0) {
+            Util.progressBar.start(totalBytes, downloadedBytes, {
+                downloadedMB,
+                totalMB
+            });
+            Util.progressBarStarted = true;
+        } else if (Util.progressBarStarted) {
+            Util.progressBar.update(downloadedBytes, {
+                downloadedMB,
+                totalMB
+            });
         }
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "puppeteer-chromium-resolver",
-    "version": "24.0.1",
+    "version": "24.0.2",
     "description": "Tool to resolve puppeteer and chromium faster, detect local installed chromium, download chromium with custom mirror host, cache chromium revision out of node_modules, test chromium headless being launchable.",
     "main": "lib/index.js",
     "scripts": {
@@ -18,8 +18,8 @@
     },
     "dependencies": {
         "@puppeteer/browsers": "^2.8.0",
+        "cli-progress": "^3.12.0",
         "eight-colors": "^1.3.1",
-        "gauge": "^5.0.2",
         "puppeteer-core": "^24.4.0"
     },
     "devDependencies": {


### PR DESCRIPTION
@cenfun The https://www.npmjs.com/package/gauge it's not longer supported by npm

This implement migrate the progress bar usage to [cli-progress](https://www.npmjs.com/package/cli-progress) keeping similar functionality