### PR TITLE
fix: add linux_arm support for some scenarioes like docker

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -2,6 +2,7 @@ const EC = require('eight-colors');
 const Util = require('./util.js');
 
 const BrowserPlatform = {
+    LINUX_ARM: 'linux_arm',
     LINUX: 'linux',
     MAC: 'mac',
     MAC_ARM: 'mac_arm',
@@ -11,6 +12,7 @@ const BrowserPlatform = {
 
 function folder(platform) {
     switch (platform) {
+        case BrowserPlatform.LINUX_ARM:
         case BrowserPlatform.LINUX:
             return 'Linux_x64';
         case BrowserPlatform.MAC_ARM:
@@ -28,6 +30,7 @@ function folder(platform) {
 
 function archive(platform, buildId) {
     switch (platform) {
+        case BrowserPlatform.LINUX_ARM:
         case BrowserPlatform.LINUX:
             return 'chrome-linux';
         case BrowserPlatform.MAC_ARM:


### PR DESCRIPTION
Some scenarios like running docker container on M series chips Mac are possible to be `linux_arm`.